### PR TITLE
Status handlers

### DIFF
--- a/pxt.json
+++ b/pxt.json
@@ -14,7 +14,7 @@
     ],
     "public": true,
     "targetVersions": {
-        "target": "1.0.16",
+        "target": "1.2.6",
         "targetId": "arcade"
     },
     "supportedTargets": [

--- a/status-bar.ts
+++ b/status-bar.ts
@@ -283,7 +283,6 @@ class StatusBarSprite extends Sprite {
         const sb = this._statusBar;
 
         if (sb) {
-            sb.current
             const output = action(sb);
             sb.updateDisplay();
             this.setImage(sb.image);
@@ -650,17 +649,17 @@ namespace statusbars {
     }
 
     export enum StatusComparison {
-        // block="="
+        //% block="="
         EQ,
-        // block="!="
+        //% block="!="
         NEQ,
-        // block=">"
+        //% block=">"
         GT,
-        // block=">="
+        //% block=">="
         GTE,
-        // block="<"
+        //% block="<"
         LT,
-        // block="<="
+        //% block="<="
         LTE,
     }
 

--- a/status-bar.ts
+++ b/status-bar.ts
@@ -796,17 +796,19 @@ namespace statusbars {
         zeroHandlers[kind] = handler;
     }
 
-    //% block="on status bar kind $kind $comparison $percent|$comparisonType $status"
+    //% block="on status bar kind $kind $comparison $value|$comparisonType $status"
     //% blockId="statusbars_onStatusReached"
     //% kind.shadow="statusbars_kind"
     //% draggableParameters="reporter"
     //% group="Events"
+    //% comparison.defl=statusbars.StatusComparison.LTE
+    //% value.defl=50
     //% weight=58
     export function onStatusReached(
         kind: number,
         comparison: StatusComparison,
         comparisonType: ComparisonType,
-        percent: number,
+        value: number,
         handler: (status: StatusBarSprite) => void
     ) {
         let statusHandlers = getStatusHandlers();
@@ -817,7 +819,7 @@ namespace statusbars {
             kind,
             comparison,
             comparisonType,
-            percent,
+            value,
             handler
         );
         statusHandlers.push(statusHandler);

--- a/status-bar.ts
+++ b/status-bar.ts
@@ -19,6 +19,9 @@ enum StatusBarFlag {
     // if set, do not destroy this status bar when sprite it is attached to is destroyed
     //% block="no autodestroy on attached destroy"
     NoAutoDestroy = 1 << 5,
+    // if set, do not run `on zero` or `on status changed` events when changing values on this status bar.
+    //% block="ignore events"
+    IgnoreValueEvents = 1 << 6,
 }
 
 namespace SpriteKind {
@@ -448,6 +451,7 @@ namespace statusbars {
             const statusHandlers = getStatusHandlers();
             const toRun = statusHandlers && statusHandlers.filter(h =>
                 h.kind === this.kind
+                    && !(this.flags & StatusBarFlag.IgnoreValueEvents)
                     && h.conditionMet(100 * current / max)
                     && !h.conditionMet(100 * this.current / this.max)
             );
@@ -455,7 +459,7 @@ namespace statusbars {
             this.target = current;
             this._max = max
 
-            if (current <= 0 && !this.hasHitZero) {
+            if (current <= 0 && !this.hasHitZero && !(this.flags & StatusBarFlag.IgnoreValueEvents)) {
                 this.hasHitZero = true;
                 const handler = (getZeroHandlers() || [])[this.kind];
                 if (this.sprite && handler)

--- a/test.ts
+++ b/test.ts
@@ -201,6 +201,6 @@ function testRelPosition() {
 
 }
 
-// testIcon()
+testIcon()
 // test1()
 // testRelPosition()

--- a/test.ts
+++ b/test.ts
@@ -202,4 +202,5 @@ function testRelPosition() {
 }
 
 // testIcon()
-testRelPosition()
+// test1()
+// testRelPosition()


### PR DESCRIPTION
fix https://github.com/jwunderl/pxt-status-bar/issues/2 -- add a block for reaching arbitrary points.

![image](https://user-images.githubusercontent.com/5615930/93148612-1e828e80-f6a9-11ea-980b-37200d1ef67f.png)

![image](https://user-images.githubusercontent.com/5615930/93148625-26423300-f6a9-11ea-8ce0-c15365da50c1.png)

Couple questions on how you all would expect it to behave / checking if you have ideas on making this make more sense (cc: 
 @darzu @livcheerful @riknoll @shakao)
* I think it makes sense to use percentages instead of specific values, but I'm not completely sure.
* Should it handle some rounding? Probably a bit unlikely to hit specific percentages for equals right now.
* What order should the comparisons be in, and is there maybe a better way to represent it than the enum? Also, if leaving as enum, should I spell out the name for the comparisons or leave in the assembly like spelling (that is, would the js api look better as `statusbars.StatusComparison.EQ` or `statusbars.StatusComparison.Equals`
* When you're just initializing things, it's possible that you'd hit the thresholds and run the event  - e.g. if you double the max and then set the value, but you have an event for health == 50%. I can move it to run on game update I suppose, so it only checks once per frame?